### PR TITLE
Fix missing return statement

### DIFF
--- a/ios/IoReactNativeCrypto.swift
+++ b/ios/IoReactNativeCrypto.swift
@@ -32,6 +32,7 @@ class IoReactNativeCrypto: NSObject {
         privateKey = try self.generatePrivateKey(keyTag: keyTag)
       } catch {
         ME.wrongKeyConfiguration.reject(reject: reject)
+        return
       }
       
       guard let privateKey = privateKey,


### PR DESCRIPTION
## Short description
This PR fixes a missing return statement in the key generation function on ios.

## List of changes proposed in this pull request
- IoReactNativeCrypto.swift: added missing return statement

## How to test
Run the example application and generate a key. No errors should happen.
