### PR TITLE
[IOAPPCIT-16] Add github action workflow for npm package publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Publish package on NPM 📦
         run: npm publish --access=public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_RELEASE_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: Publish to NPM
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+      - name: Setup Node
+        uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install dependencies and build with builder bob
+        run: yarn install --frozen-lockfile
+      - name: Publish package on NPM 📦
+        run: npm publish --access=public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/io-react-native-crypto",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "test",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Short description
This PR adds a GitHub Action workflow to publish the release package to the NPM registry.
To read better how it works look [here](https://pagopa.atlassian.net/wiki/spaces/IOAPP/pages/613679535/GitHub+Action+how+to+publish+an+NPM+package).

## List of changes proposed in this pull request
- .github/workflows/publish.yml: this is the github action workflow triggered when a new release has been created.
- package.json: bumps the package version from 0.2.0 to 0.2.1
