### PR TITLE
fix: [SIW-2627] CRL validation failure when verifying a self-signed certificate used both as leaf and anchor

### DIFF
--- a/ios/X509VerificationUtils.swift
+++ b/ios/X509VerificationUtils.swift
@@ -514,7 +514,7 @@ class X509VerificationUtils {
     let issuerCert: SecCertificate? =
       SecTrustGetCertificateCount(trust) > 1
       ? SecTrustGetCertificateAtIndex(trust, 1)
-      : nil
+      : SecTrustGetCertificateAtIndex(trust, 0)
     let issuerDER: Data? = issuerCert.map { SecCertificateCopyData($0) as Data }
 
     X509RevocationChecker.isCertRevokedByCRL(


### PR DESCRIPTION
## Short description  
Fix CRL validation failure when verifying a self-signed certificate used both as leaf and trust anchor.
## List of changes proposed in this pull request  
- Fix `issuerDER` fallback in CRL check to support self-signed root certificates  
- Prevent false negatives in `check_cert_revocation_with_crl` due to missing issuer pointer

## How to test  

To reproduce and verify the fix:

1. Use a self-signed certificate as both the `certChainBase64[0]` and `trustAnchorCertBase64`.
2. Set `requireCrl: true` in the `options` object.
3. Ensure the certificate includes a valid CRL Distribution Point.
4. Run `verifyCertificateChain(...)` from the React Native bridge.
5. Expected result: validation should succeed if the cert is not revoked and the CRL is valid.
