### PR TITLE
fix: [SIW-2635] Fix ReadableArray.getString() to support RN 0.78

### DIFF
--- a/android/src/main/java/com/pagopa/ioreactnativecrypto/IoReactNativeCryptoModule.kt
+++ b/android/src/main/java/com/pagopa/ioreactnativecrypto/IoReactNativeCryptoModule.kt
@@ -527,11 +527,8 @@ class IoReactNativeCryptoModule(reactContext: ReactApplicationContext) :
     moduleScope.launch { // Launch in module's coroutine scope
       try {
         // 1. Convert ReadableArray to List<String> safely
-        val chainList: List<String> = mutableListOf<String>().apply {
-          for (i in 0 until certChainBase64.size()) {
-            add(certChainBase64.getString(i))
-          }
-        }
+        val chainList: List<String> = (0 until certChainBase64.size())
+          .mapNotNull { certChainBase64.getString(it) }
 
         if (chainList.isEmpty()) {
           throw IllegalArgumentException("Certificate chain array is empty.")


### PR DESCRIPTION
## Short description  
Fixes a crash occurring in React Native 0.78+ caused by unsafe usage of `ReadableArray.getString(index)` without null checks.

## List of changes proposed in this pull request  
- Updated the `verifyCertificateChain` method to safely convert a `ReadableArray` to a `List<String>` using a null-safe approach. 

## How to test  
1. Use the `verifyCertificateChain` method in an app built with React Native 0.75.x, it should work as expected.  
2. Use the `verifyCertificateChain` method in an app built with React Native 0.78.x, it should work as expected.  
